### PR TITLE
Automatically load g:fzf_action if set

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Usual shortcuts from FZF are enabled:
 * `ctrl-v`: go to location in a vertical split
 * `ctrl-x`: go to location in a horizontal split
 
-This plugin will also try to load FZF actions keymaps from `g:fzf_action` if
-it is set at the time `setup` is called.
+This plugin will try to load FZF action keymaps from `g:fzf_action` if it's
+set when `setup` is called.
 
 ## Supported LSP methods
 You can enable FZF only for a subset of LSP methods by passing them as a list

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ with their default settings:
 require('lspfuzzy').setup {
   methods = 'all',        -- either 'all' or a list of LSP methods (see below)
   fzf_options = {},       -- options passed to FZF
+  fzf_action = {          -- FZF action default keymaps
+    ['ctrl-t'] = 'tabedit',  -- open in a new tab
+    ['ctrl-v'] = 'vsplit',   -- open in a vertical split
+    ['ctrl-x'] = 'split',    -- open in a horizontal split
+  },
   fzf_modifier = ':~:.',  -- format FZF entries, see |filename-modifiers|
   fzf_trim = true,        -- trim FZF entries
 }
@@ -83,6 +88,9 @@ Usual shortcuts from FZF are enabled:
 * `ctrl-t`: go to location in a new tab
 * `ctrl-v`: go to location in a vertical split
 * `ctrl-x`: go to location in a horizontal split
+
+This plugin will also try to load FZF actions keymaps from `g:fzf_action` if
+it is set at the time `setup` is called.
 
 ## Supported LSP methods
 You can enable FZF only for a subset of LSP methods by passing them as a list

--- a/README.md
+++ b/README.md
@@ -68,19 +68,19 @@ You can pass options to the `setup()` function. Here are all available options
 with their default settings:
 ```lua
 require('lspfuzzy').setup {
-  methods = 'all',        -- either 'all' or a list of LSP methods (see below)
-  fzf_options = {},       -- options passed to FZF
-  fzf_action = {          -- FZF action default keymaps
+  methods = 'all',         -- either 'all' or a list of LSP methods (see below)
+  fzf_options = {},        -- options passed to FZF
+  fzf_action = {           -- additional FZF commands
     ['ctrl-t'] = 'tabedit',  -- open in a new tab
     ['ctrl-v'] = 'vsplit',   -- open in a vertical split
     ['ctrl-x'] = 'split',    -- open in a horizontal split
   },
-  fzf_modifier = ':~:.',  -- format FZF entries, see |filename-modifiers|
-  fzf_trim = true,        -- trim FZF entries
+  fzf_modifier = ':~:.',   -- format FZF entries, see |filename-modifiers|
+  fzf_trim = true,         -- trim FZF entries
 }
 ```
 
-Usual shortcuts from FZF are enabled:
+By default the following FZF commands are available:
 * `tab`: select multiple entries
 * `shift+tab`: deselect an entry
 * `ctrl-a`: select all entries
@@ -89,8 +89,12 @@ Usual shortcuts from FZF are enabled:
 * `ctrl-v`: go to location in a vertical split
 * `ctrl-x`: go to location in a horizontal split
 
-This plugin will try to load FZF action keymaps from `g:fzf_action` if it's
-set when `setup` is called.
+The active FZF commands are determined as follows:
+1. Commands passed to the `fzf_action` option when calling `setup()` are used
+  first.
+2. Otherwise the plugin will try to load commands from the FZF option
+  `g:fzf_action` if it's set.
+3. Finally the default commands will be used.
 
 ## Supported LSP methods
 You can enable FZF only for a subset of LSP methods by passing them as a list

--- a/lua/lspfuzzy.lua
+++ b/lua/lspfuzzy.lua
@@ -47,7 +47,7 @@ local function jump(entries)
   if not entries or #entries < 2 then return end
   local key = table.remove(entries, 1)
   local locations = vim.tbl_map(fzf_to_lsp, entries)
-  if opts.fzf_action[key] ~= nil then  -- user has used ctrl-t/ctrl-v/ctrl-x
+  if opts.fzf_action[key] ~= nil then  -- user has used FZF keymaps
     cmd(opts.fzf_action[key])
   end
   if #locations > 1 then  -- use quickfix list to store remaining locations

--- a/lua/lspfuzzy.lua
+++ b/lua/lspfuzzy.lua
@@ -10,10 +10,10 @@ local lsp = require 'vim.lsp'
 local opts = {
   methods = 'all',        -- either 'all' or a list of LSP methods
   fzf_options = {},       -- options passed to FZF
-  fzf_action = {     -- FZF action default keymaps
-    -- ['ctrl-t'] = 'tabedit',  -- open in a new tab
-    -- ['ctrl-v'] = 'vsplit',   -- open in a vertical split
-    -- ['ctrl-x'] = 'split',    -- open in a horizontal split
+  fzf_action = {          -- FZF action default keymaps
+    ['ctrl-t'] = 'tabedit',  -- open in a new tab
+    ['ctrl-v'] = 'vsplit',   -- open in a vertical split
+    ['ctrl-x'] = 'split',    -- open in a horizontal split
   },
   fzf_modifier = ':~:.',  -- format FZF entries, see |filename-modifiers|
   fzf_trim = true,        -- trim FZF entries
@@ -145,8 +145,8 @@ local function set_handler(method)
 end
 
 local function setup(user_opts)
-  if vim.g.fzf_action != nil then
-    opts.fzf_action = vim.g.fzf_action
+  if g.fzf_action ~= nil then
+    opts.fzf_action = g.fzf_action
   end
   opts = vim.tbl_extend('keep', user_opts, opts)
   local methods = opts.methods

--- a/lua/lspfuzzy.lua
+++ b/lua/lspfuzzy.lua
@@ -144,10 +144,17 @@ local function set_handler(method)
   lsp.handlers[method] = handlers[method]
 end
 
-local function setup(user_opts)
+local function load_fzf_opts()
+  fzf_opts = {}
+  -- FZF action keymaps
   if g.fzf_action ~= nil then
-    opts.fzf_action = g.fzf_action
+    fzf_opts.fzf_action = g.fzf_action
   end
+  return fzf_opts
+end
+
+local function setup(user_opts)
+  opts = vim.tbl_extend('keep', load_fzf_opts(), opts)
   opts = vim.tbl_extend('keep', user_opts, opts)
   local methods = opts.methods
   if methods == 'all' then

--- a/lua/lspfuzzy.lua
+++ b/lua/lspfuzzy.lua
@@ -8,15 +8,15 @@ local lsp = require 'vim.lsp'
 
 -------------------- OPTIONS -------------------------------
 local opts = {
-  methods = 'all',        -- either 'all' or a list of LSP methods
-  fzf_options = {},       -- options passed to FZF
-  fzf_action = {          -- FZF action default keymaps
+  methods = 'all',         -- either 'all' or a list of LSP methods
+  fzf_options = {},        -- options passed to FZF
+  fzf_action = {           -- additional FZF commands
     ['ctrl-t'] = 'tabedit',  -- open in a new tab
     ['ctrl-v'] = 'vsplit',   -- open in a vertical split
     ['ctrl-x'] = 'split',    -- open in a horizontal split
   },
-  fzf_modifier = ':~:.',  -- format FZF entries, see |filename-modifiers|
-  fzf_trim = true,        -- trim FZF entries
+  fzf_modifier = ':~:.',   -- format FZF entries, see |filename-modifiers|
+  fzf_trim = true,         -- trim FZF entries
 }
 
 -------------------- HELPERS -------------------------------
@@ -47,7 +47,7 @@ local function jump(entries)
   if not entries or #entries < 2 then return end
   local key = table.remove(entries, 1)
   local locations = vim.tbl_map(fzf_to_lsp, entries)
-  if opts.fzf_action[key] ~= nil then  -- user has used FZF keymaps
+  if opts.fzf_action[key] then  -- a FZF action was used
     cmd(opts.fzf_action[key])
   end
   if #locations > 1 then  -- use quickfix list to store remaining locations
@@ -144,17 +144,10 @@ local function set_handler(method)
   lsp.handlers[method] = handlers[method]
 end
 
-local function load_fzf_opts()
-  fzf_opts = {}
-  -- FZF action keymaps
-  if g.fzf_action ~= nil then
-    fzf_opts.fzf_action = g.fzf_action
-  end
-  return fzf_opts
-end
-
 local function setup(user_opts)
-  opts = vim.tbl_extend('keep', load_fzf_opts(), opts)
+  if g.fzf_action then  -- use the FZF action option instead of defaults
+    opts.fzf_action = g.fzf_action
+  end
   opts = vim.tbl_extend('keep', user_opts, opts)
   local methods = opts.methods
   if methods == 'all' then

--- a/lua/lspfuzzy.lua
+++ b/lua/lspfuzzy.lua
@@ -10,6 +10,11 @@ local lsp = require 'vim.lsp'
 local opts = {
   methods = 'all',        -- either 'all' or a list of LSP methods
   fzf_options = {},       -- options passed to FZF
+  fzf_action = {     -- FZF action default keymaps
+    -- ['ctrl-t'] = 'tabedit',  -- open in a new tab
+    -- ['ctrl-v'] = 'vsplit',   -- open in a vertical split
+    -- ['ctrl-x'] = 'split',    -- open in a horizontal split
+  },
   fzf_modifier = ':~:.',  -- format FZF entries, see |filename-modifiers|
   fzf_trim = true,        -- trim FZF entries
 }
@@ -38,18 +43,12 @@ local function fzf_to_lsp(entry)
 end
 
 -------------------- FZF FUNCTIONS -------------------------
-local fzf_actions = {
-  ['ctrl-t'] = 'tabedit',  -- open in a new tab
-  ['ctrl-v'] = 'vsplit',   -- open in a vertical split
-  ['ctrl-x'] = 'split',    -- open in a horizontal split
-}
-
 local function jump(entries)
   if not entries or #entries < 2 then return end
   local key = table.remove(entries, 1)
   local locations = vim.tbl_map(fzf_to_lsp, entries)
-  if fzf_actions[key] ~= nil then  -- user has used ctrl-t/ctrl-v/ctrl-x
-    cmd(fzf_actions[key])
+  if opts.fzf_action[key] ~= nil then  -- user has used ctrl-t/ctrl-v/ctrl-x
+    cmd(opts.fzf_action[key])
   end
   if #locations > 1 then  -- use quickfix list to store remaining locations
     lsp.util.set_qflist(lsp.util.locations_to_items(locations))
@@ -69,7 +68,7 @@ local function fzf(source)
     fzf_opts = {
       '--ansi',
       '--bind', 'ctrl-a:select-all,ctrl-d:deselect-all',
-      '--expect', table.concat(vim.tbl_keys(fzf_actions), ','),
+      '--expect', table.concat(vim.tbl_keys(opts.fzf_action), ','),
       '--multi',
     }
     if pcall(fn['fzf#vim#with_preview']) then  -- enable preview with fzf.vim
@@ -146,6 +145,9 @@ local function set_handler(method)
 end
 
 local function setup(user_opts)
+  if vim.g.fzf_action != nil then
+    opts.fzf_action = vim.g.fzf_action
+  end
   opts = vim.tbl_extend('keep', user_opts, opts)
   local methods = opts.methods
   if methods == 'all' then


### PR DESCRIPTION
Hi!

I use FZF on nvim with the `g:fzf_action` variable set:

```vim
let g:fzf_action = 
  \ { 'ctrl-g': 'tab split',
  \   'ctrl-s': 'split',
  \   'ctrl-v': 'vsplit' }
```

I wanted this to automatically load when I call `require'lspfuzzy'.setup{}`. That's what this PR does.

This is my first time coding in Lua. I hope things look fine.