### PR TITLE
Update to use new lsp handler signatures

### DIFF
--- a/lua/lspfuzzy.lua
+++ b/lua/lspfuzzy.lua
@@ -234,16 +234,30 @@ local handlers = {
 }
 
 local function wrap_handler(handler)
-  return function(err, method, result, client_id, bufnr, config)
-    if err then
-      return echo('ErrorMsg', err.message)
-    end
+  if vim.fn.has("nvim-0.5.1") then
+    return function(err, result, context, config)
+      if err then
+          return echo('ErrorMsg', err.message)
+      end
 
-    if not result or vim.tbl_isempty(result) then
-      return echo('None', fmt('No %s found', string.lower(handler.label)))
-    end
+      if not result or vim.tbl_isempty(result) then
+          return echo('None', fmt('No %s found', string.lower(handler.label)))
+      end
 
-    return handler.target(handler.label, result, client_id, bufnr, config)
+      return handler.target(handler.label, result, context.client_id, context.bufnr, config)
+    end
+  else
+    return function(err, method, result, client_id, bufnr, config)
+      if err then
+          return echo('ErrorMsg', err.message)
+      end
+
+      if not result or vim.tbl_isempty(result) then
+          return echo('None', fmt('No %s found', string.lower(handler.label)))
+      end
+
+      return handler.target(handler.label, result, client_id, bufnr, config)
+    end
   end
 end
 


### PR DESCRIPTION
Recently, `master` branch of NeoVim takes a breaking change regarding LSP handler signatures: https://github.com/neovim/neovim/pull/15504

This PR deals with the breaking change while preserving the behavior for the latest stable version of NeoVim (0.5.0).

#### NOTE:

Although this PR fixes the problem for the majority of people, people who use the NeoVim whose version is greater than `0.5.0` but less than https://github.com/neovim/neovim/pull/15504 still faces the problem, since such version of NeoVim returns `1` for `vim.fn.has("nvim-0.5.1")` but still use old handler signatures.

Technically, we can make this plugin work fine for all three cases like below at the same time by making the handlers check the type of arguments (string / table):

- `0.5.0`
- greater than `0.5.0`, less than https://github.com/neovim/neovim/pull/15504
- greater than https://github.com/neovim/neovim/pull/15504p

But, since doing so will make the codebase a bit dirty, I think just checking the version of NeoVim whether it has `nvim-0.5.1` as this PR does is better.