### PR TITLE
Color filenames and line number

### DIFF
--- a/lua/lspfuzzy.lua
+++ b/lua/lspfuzzy.lua
@@ -6,6 +6,9 @@
 local fmt = string.format
 local offset_encoding    -- hold client offset encoding (see :h vim.lsp.client)
 local last_results = {}  -- hold last location results
+local ansi_purple = '\u{001b}[35m'
+local ansi_green = '\u{001b}[32m'
+local ansi_reset = '\u{001b}[0m'
 
 -------------------- OPTIONS -------------------------------
 local opts = {
@@ -35,7 +38,11 @@ end
 local function lsp_to_fzf(item)
   local path = vim.fn.fnamemodify(item.filename, opts.fzf_modifier)
   local text = opts.fzf_trim and vim.trim(item.text) or item.text
-  return fmt('%s:%s:%s: %s', path, item.lnum, item.col, text)
+  return fmt(
+    ansi_purple .. '%s:'
+    .. ansi_green .. '%s:'
+    .. ansi_reset .. '%s: %s', path, item.lnum, item.col, text
+  )
 end
 
 local function fzf_to_lsp(entry)


### PR DESCRIPTION
It's kind of hard to parse the results within the fzf window because the filename and line contents are all one color. This PR uses ANSI escape sequences to make the filename purple and the line number green matching the default colors for `:Rg` on the fzf plugin which also colorizes output to help with visually parsing it

Example:
![lspfuzzy_pr_ss](https://user-images.githubusercontent.com/19642235/166179646-1d34fe8b-b7c5-413c-9a72-36012fe8a3e1.png)
.