### PR TITLE
Fix unknown escape sequence 

### DIFF
--- a/lua/lspfuzzy.lua
+++ b/lua/lspfuzzy.lua
@@ -7,9 +7,9 @@ local fmt = string.format
 local offset_encoding    -- hold client offset encoding (see :h vim.lsp.client)
 local last_results = {}  -- hold last location results
 local ansi = {
-  reset = '\u{001b}[0m',
-  green = '\u{001b}[32m',
-  purple = '\u{001b}[35m',
+  reset = string.char(0x001b) .. '[0m',
+  green = string.char(0x001b) .. '[32m',
+  purple = string.char(0x001b) .. '[35m',
 }
 
 -------------------- OPTIONS -------------------------------


### PR DESCRIPTION
Hi, thanks for this plugin!

I think because I'm using a build of neovim with luajit 2.0.5 rather than 2.1.0-beta, I was getting an error for these escape sequences. This PR will work for both versions.