### PR TITLE
handle `jump_to_location` deprecation in nvim 0.11

### DIFF
--- a/lua/lspfuzzy.lua
+++ b/lua/lspfuzzy.lua
@@ -65,7 +65,12 @@ local function fzf_to_lsp(entry)
 end
 
 local function jump_to_location(location)
-  vim.lsp.util.jump_to_location(location, offset_encoding)
+  local show_document = vim.lsp.util.show_document
+  if show_document then
+    show_document(location, offset_encoding, {focus = true})
+  else
+    vim.lsp.util.jump_to_location(location, offset_encoding)
+  end
   if type(opts.callback) == 'function' then
     opts.callback()
   end


### PR DESCRIPTION
Invoked `show_document` if present (such as in 0.11) instead of `jump_to_location`, see this PR for reference:

https://github.com/mrcjkb/rustaceanvim/pull/711